### PR TITLE
make dom.text(el, 0) populate el with the string '0'

### DIFF
--- a/ampersand-dom.js
+++ b/ampersand-dom.js
@@ -65,7 +65,7 @@ var dom = module.exports = {
 
 // helpers
 function getString(val) {
-    if (!val) {
+    if (!val && val !== 0) {
         return '';
     } else {
         return val;

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,25 @@ suite('text', function (s) {
         t.end();
     });
 
+    s.test('falsy values', function(t) {
+        dom.text(fixture, 0);
+        t.equal(fixture.innerHTML, '0');
+
+        dom.text(fixture, undefined);
+        t.equal(fixture.innerHTML, '');
+
+        dom.text(fixture, null);
+        t.equal(fixture.innerHTML, '');
+
+        dom.text(fixture, NaN);
+        t.equal(fixture.innerHTML, '');
+
+        dom.text(fixture, false);
+        t.equal(fixture.innerHTML, '');
+
+        t.end();
+    });
+
     s.test('on text node', function (t) {
         var node1 = document.createTextNode('hello');
         var node2 = document.createTextNode('there');


### PR DESCRIPTION
The [ampersand-dom-bindings docs](http://ampersandjs.com/docs#ampersand-dom-bindings-text) say that a binding where type=text will treat `undefined`, `null`, and `NaN` as `''` - which makes perfect sense. However, I think it makes sense to treat the numeric value `0` as the string `"0"` - otherwise, any numeric field on state or model objects that use a text binding will be blank if their value is 0.

This commit adds tests for how `dom.text` treats all falsy values and makes a change so that `0` is treated as a number and becomes `"0"`.
