### PR TITLE
Workaround an issue when using setAttribute to modify the value attribute in an input element

### DIFF
--- a/ampersand-dom.js
+++ b/ampersand-dom.js
@@ -43,6 +43,10 @@ var dom = module.exports = {
     },
     // sets attribute to string value given, clearing any current value
     setAttribute: function (el, attr, value) {
+        if (attr === 'value' && el.hasOwnProperty('value')) {
+            el[attr] = value;
+            return;
+        }
         el.setAttribute(attr, getString(value));
     },
     getAttribute: function (el, attr) {

--- a/test/index.js
+++ b/test/index.js
@@ -131,6 +131,18 @@ suite('attributes', function (s) {
         t.end();
     });
 
+    s.test('set value attribute', function (t) {
+        var input = document.createElement('input');
+        input.setAttribute('type', 'text');
+        fixture.appendChild(input);
+
+        input.value = 20;
+        dom.setAttribute(input, 'value', 10);
+        t.equal(input.value, '10');
+
+        t.end();
+    });
+
     s.test('set/get/remove', function (t) {
         dom.setAttribute(fixture, 'foo', 'bar');
         t.equal(fixture.getAttribute('foo'), 'bar');


### PR DESCRIPTION
Here's the issue in a plain test:

![dombug](https://cloud.githubusercontent.com/assets/1460090/3557031/f193345a-092a-11e4-983d-b5441ebc7cf8.gif)
