### PR TITLE
add phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "browserify": "~4.1.8",
+    "phantomjs": "^1.9.7-15",
     "run-browser": "~1.3.1",
     "tap-spec": "^0.2.0",
     "tape": "^2.13.2",


### PR DESCRIPTION
Required as a dev dependency so tests will run if it is not installed globally.
