### PR TITLE
Add toggle to simplify show/hide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ dom.hide(el);
 // based on tagname and getComputedStyle()
 dom.show(el);
 
+// toggle display of element, between show/hide
+dom.toggle(el);
+
 // sets inner HTML, takes string or DOM
 dom.html(el, '<div></div>');
 ```

--- a/ampersand-dom.js
+++ b/ampersand-dom.js
@@ -62,6 +62,14 @@ var dom = module.exports = {
     show: function (el) {
         show(el);
     },
+    toggle: function (el) {
+        if (!isHidden(el)) {
+            storeDisplayStyle(el);
+            hide(el);
+        } else {
+            show(el);
+        }
+    },
     html: function (el, content) {
         el.innerHTML = content;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -177,7 +177,7 @@ function isHidden(el) {
     return false;
 }
 
-suite('show/hide', function (s) {
+suite('show/hide/toggle', function (s) {
     s.beforeEach(resetFixture);
     var el;
 
@@ -200,7 +200,7 @@ suite('show/hide', function (s) {
         t.end();
     });
 
-    s.test('simple', function (t) {
+    s.test('double', function (t) {
         t.notOk(isHidden(el));
 
         dom.hide(el);
@@ -210,6 +210,21 @@ suite('show/hide', function (s) {
         t.ok(isHidden(el));
 
         dom.show(el);
+        t.notOk(isHidden(el));
+
+        dom.show(el);
+        t.notOk(isHidden(el));
+
+        t.end();
+    });
+
+    s.test('toggle', function (t) {
+        t.notOk(isHidden(el));
+
+        dom.toggle(el);
+        t.ok(isHidden(el));
+
+        dom.toggle(el);
         t.notOk(isHidden(el));
 
         t.end();
@@ -228,6 +243,13 @@ suite('show/hide', function (s) {
         t.notOk(isHidden(el));
         t.equal(s.getPropertyValue('display'), 'table');
 
+        dom.toggle(el);
+        t.ok(isHidden(el));
+
+        dom.toggle(el);
+        t.notOk(isHidden(el));
+        t.equal(s.getPropertyValue('display'), 'table');
+
         t.end();
     });
 
@@ -239,6 +261,13 @@ suite('show/hide', function (s) {
         t.ok(isHidden(el));
 
         dom.show(el);
+        t.notOk(isHidden(el));
+        t.equal(el.style.display, 'table');
+
+        dom.toggle(el);
+        t.ok(isHidden(el));
+
+        dom.toggle(el);
         t.notOk(isHidden(el));
         t.equal(el.style.display, 'table');
 


### PR DESCRIPTION
Perhaps there's an easier way to do this. I'm trying to show and hide a subview (which holds a collection), based on a click event.
If there's not a better way, this seems to work well.

Here's my use case:
view:
```
    events: {
        'click [data-hook~=toggle_activities]': 'toggleActivities'
    },
    toggleActivities: function () {
        var activitiesEl = this.queryByHook('activities');
        dom.toggle(activitiesEl);
    },
    subviews: {
        activities: {
            container: '[data-hook=activities]',
            waitFor: 'model.activities',
            prepareView: function(el) {
                return new CollectionRenderer({
                    el: el,
                    collection: this.model.activities,
                    view: ActivityView
                });
            }
        }
    },
```
template:
```
    <button data-hook="toggle_activities" class="btn">Activities</button>
    <div data-hook="activities"></div>
```