### PR TITLE
Add ability to toggle visibility with show/hide functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,15 @@ dom.setAttribute(el, 'value', 'the value');
 // sets display none
 dom.hide(el);
 
+// sets visibility hidden
+dom.hide(el, 'visibility');
+
 // shows element, trying to determine it's default display state
 // based on tagname and getComputedStyle()
 dom.show(el);
+
+// sets visibility on element based on its previous value
+dom.show(el, 'visibility');
 
 // sets inner HTML, takes string or DOM
 dom.html(el, '<div></div>');

--- a/ampersand-dom.js
+++ b/ampersand-dom.js
@@ -62,15 +62,17 @@ var dom = module.exports = {
     getAttribute: function (el, attr) {
         return el.getAttribute(attr);
     },
-    hide: function (el) {
+    hide: function (el, mode) {
+        if (!mode) mode = 'display';
         if (!isHidden(el)) {
-            storeDisplayStyle(el);
-            hide(el);
+            storeDisplayStyle(el, mode);
+            hide(el, mode);
         }
     },
     // show element
-    show: function (el) {
-        show(el);
+    show: function (el, mode) {
+        if (!mode) mode = 'display';
+        show(el, mode);
     },
     html: function (el, content) {
         el.innerHTML = content;
@@ -103,16 +105,16 @@ function isHidden (el) {
     return dom.getAttribute(el, 'data-anddom-hidden') === 'true';
 }
 
-function storeDisplayStyle (el) {
-    dom.setAttribute(el, 'data-anddom-display', el.style.display);
+function storeDisplayStyle (el, mode) {
+    dom.setAttribute(el, 'data-anddom-' + mode, el.style[mode]);
 }
 
-function show (el) {
-    el.style.display = dom.getAttribute(el, 'data-anddom-display') || '';
+function show (el, mode) {
+    el.style[mode] = dom.getAttribute(el, 'data-anddom-' + mode) || '';
     dom.removeAttribute(el, 'data-anddom-hidden');
 }
 
-function hide (el) {
+function hide (el, mode) {
     dom.setAttribute(el, 'data-anddom-hidden', 'true');
-    el.style.display = 'none';
+    el.style[mode] = (mode === 'visibility' ? 'hidden' : 'none');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -185,10 +185,16 @@ suite('attributes', function (s) {
     });
 });
 
-function isHidden(el) {
-    if (el.style.display === 'none') return true;
-    if (window.getComputedStyle(el).display === 'none') return true;
-    return false;
+function isHidden(el, visibility) {
+    if (visibility) {
+        if (el.style.visibility === 'hidden') return true;
+        if (window.getComputedStyle(el).visibility === 'hidden') return true;
+        return false;
+    } else {
+        if (el.style.display === 'none') return true;
+        if (window.getComputedStyle(el).display === 'none') return true;
+        return false;
+    }
 }
 
 suite('show/hide', function (s) {
@@ -255,6 +261,18 @@ suite('show/hide', function (s) {
         dom.show(el);
         t.notOk(isHidden(el));
         t.equal(el.style.display, 'table');
+
+        t.end();
+    });
+
+    s.test('with use of visibility property', function (t) {
+        t.notOk(isHidden(el, true), 'should not have a visibility property to start with');
+
+        dom.hide(el, 'visibility');
+        t.ok(isHidden(el, true), 'should have visibility set to hidden');
+
+        dom.show(el, 'visibility');
+        t.notOk(isHidden(el, true), 'should have visibility set back to previous property');
 
         t.end();
     });


### PR DESCRIPTION
For: https://github.com/AmpersandJS/ampersand-dom-bindings/pull/31

I was a bit conflicted on how to implement this, specifically for `dom.show`. I wasn't sure if it should have to be passed the mode as well, or if it should automatically know (maybe with storing the mode in an attribute). I ended up going with passing the mode, so they can be independent of each other. I'm open to either though.