### PR TITLE
Fix removeClass when el is an SVG node in IE

### DIFF
--- a/ampersand-dom.js
+++ b/ampersand-dom.js
@@ -32,8 +32,16 @@ var dom = module.exports = {
             cls = getString(cls);
             if (cls) el.classList.remove(cls);
         } else {
-            // may be faster to not edit unless we know we have it?
-            el.className = el.className.replace(new RegExp('(^|\\b)' + cls.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
+            // gets class or classes separated by spaces
+            var clsFinder = new RegExp('(^|\\b)' + cls.split(' ').join('|') + '(\\b|$)', 'gi');
+            if(typeof el.className === 'object'){
+              // node is an SVG
+              var currentClasses = el.getAttribute('class') || '';
+              el.setAttribute('class', currentClasses.replace(clsFinder, ' '));
+            } else {
+              // may be faster to not edit unless we know we have it?
+              el.className = el.className.replace(clsFinder, ' ');
+            }
         }
     },
     hasClass: hasClass,

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,9 @@ var fixture = document.createElement('div');
 fixture.id = 'fixture';
 document.body.appendChild(fixture);
 
+var svg = document.createElement('svg');
+document.body.appendChild(svg);
+
 var style = document.createElement('style');
 style.innerHTML = '';
 document.body.appendChild(style);
@@ -120,8 +123,24 @@ suite('classes', function (s) {
         t.notOk(dom.hasClass(fixture, 'bar'));
         t.notOk(dom.hasClass(fixture, 'baz'));
 
+        // Tests for svg elements
+        dom.addClass(svg, 'foo');
+        t.equal(normalizeString(svg.getAttribute('class')), 'foo');
+        t.ok(dom.hasClass(svg, 'foo'));
+
+        dom.addClass(svg, 'bar');
+        t.equal(normalizeString(svg.getAttribute('class')), 'foo bar');
+        t.ok(dom.hasClass(svg, 'foo'));
+        t.ok(dom.hasClass(svg, 'bar'));
+
+        dom.removeClass(svg, 'bar');
+        t.equal(normalizeString(svg.getAttribute('class')), 'foo');
+        t.notOk(dom.hasClass(svg, 'bar'));
+        t.ok(dom.hasClass(svg, 'foo'));
+
         t.doesNotThrow(function () {
             dom.removeClass(fixture, '');
+            dom.removeClass(svg, '');
         }, 'should not complain when removing empty class');
 
         t.end();


### PR DESCRIPTION
Unfortunately in IE11 (and probably other versions) SVG elements don't expose a `classList`, and `className` is an `Object` instead of a `String`. This fixes `removeClass` so it checks `className` type and uses `replace` if `el` is a normal DOM element, `setAttribute` if it's a SVG.
